### PR TITLE
feat(neurolyzer): Make all UI label positions configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,23 +361,24 @@ Select "No" when asked about changing the MAC on startup.
 3. **Configure the Plugin:**
    Edit `/etc/pwnagotchi/config.toml`:
    ```toml
-   main.plugins.neurolyzer.enabled = true
-   main.plugins.neurolyzer.wifi_interface = "wlan0mon"  # Your wireless adapter
-   main.plugins.neurolyzer.operation_mode = "noided"    # 'normal', 'stealth', or 'noided'
-   main.plugins.neurolyzer.mac_change_interval = 3600   # Seconds
-   # -- UI Label Positions --
-   main.plugins.neurolyzer.mode_label_x = 101
-   main.plugins.neurolyzer.mode_label_y = 50
-   main.plugins.neurolyzer.next_mac_change_label_x = 101
-   main.plugins.neurolyzer.next_mac_change_label_y = 60
-   main.plugins.neurolyzer.tx_power_label_x = 0
-   main.plugins.neurolyzer.tx_power_label_y = 20
-   main.plugins.neurolyzer.channel_label_x = 0
-   main.plugins.neurolyzer.channel_label_y = 30
-   main.plugins.neurolyzer.stealth_label_x = 0
-   main.plugins.neurolyzer.stealth_label_y = 40
-   # ------------------------
-   main.plugins.neurolyzer.stealth_level = 2  # Optional: Initial stealth level (1=aggressive, 2=medium, 3=passive); still adapts dynamically
+    main.plugins.neurolyzer.enabled = true
+    main.plugins.neurolyzer.wifi_interface = "wlan0mon"  # Your wireless adapter
+    main.plugins.neurolyzer.operation_mode = "noided"    # 'normal', 'stealth', or 'noided'
+    main.plugins.neurolyzer.mac_change_interval = 3600   # Seconds
+    # -- UI Label Positions --
+    main.plugins.neurolyzer.mode_label_x = 0
+    main.plugins.neurolyzer.mode_label_y = 35
+    main.plugins.neurolyzer.next_mac_change_label_x = 0
+    main.plugins.neurolyzer.next_mac_change_label_y = 45
+    main.plugins.neurolyzer.tx_power_label_x = 0
+    main.plugins.neurolyzer.tx_power_label_y = 55
+    main.plugins.neurolyzer.channel_label_x = 0
+    main.plugins.neurolyzer.channel_label_y = 65
+    main.plugins.neurolyzer.stealth_label_x = 0
+    main.plugins.neurolyzer.stealth_label_y = 75
+    # ------------------------
+    main.plugins.neurolyzer.stealth_level = 2  # Optional: Initial stealth level (1=aggressive, 2=medium, 3=passive); still adapts dynamically
+
    ```
 
    For maximum stealth:

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ The Neurolyzer plugin has evolved into a powerful tool for enhancing the stealth
 
 ### 9. Enhanced UI Integration
 - **What's Improved:** Displays detailed status on the Pwnagotchi UI.
-- **How It Works:** Shows mode, next MAC change time, TX power, and channel, with customizable positions.
+- **How It Works:** Shows mode, next MAC change time, TX power, and channel. The positions for all these labels are fully customizable in `config.toml`.
 - **What's Better:** Offers real-time monitoring, improving on the basic UI updates of past releases.
 
 ### 10. Improved Error Handling and Logging
@@ -365,10 +365,18 @@ Select "No" when asked about changing the MAC on startup.
    main.plugins.neurolyzer.wifi_interface = "wlan0mon"  # Your wireless adapter
    main.plugins.neurolyzer.operation_mode = "noided"    # 'normal', 'stealth', or 'noided'
    main.plugins.neurolyzer.mac_change_interval = 3600   # Seconds
+   # -- UI Label Positions --
    main.plugins.neurolyzer.mode_label_x = 101
    main.plugins.neurolyzer.mode_label_y = 50
    main.plugins.neurolyzer.next_mac_change_label_x = 101
    main.plugins.neurolyzer.next_mac_change_label_y = 60
+   main.plugins.neurolyzer.tx_power_label_x = 0
+   main.plugins.neurolyzer.tx_power_label_y = 20
+   main.plugins.neurolyzer.channel_label_x = 0
+   main.plugins.neurolyzer.channel_label_y = 30
+   main.plugins.neurolyzer.stealth_label_x = 0
+   main.plugins.neurolyzer.stealth_label_y = 40
+   # ------------------------
    main.plugins.neurolyzer.stealth_level = 2  # Optional: Initial stealth level (1=aggressive, 2=medium, 3=passive); still adapts dynamically
    ```
 

--- a/neurolyzer.py
+++ b/neurolyzer.py
@@ -273,6 +273,28 @@ class Neurolyzer(plugins.Plugin):
         self.whitelist_ssids = self.options.get('whitelist_ssids', [])
         self.enabled = self.options.get('enabled', True)
 
+        # Reworked UI configuration loading
+        self.ui_config['mode'] = (
+            self.options.get('mode_label_x', self.ui_config['mode'][0]),
+            self.options.get('mode_label_y', self.ui_config['mode'][1])
+        )
+        self.ui_config['mac_timer'] = (
+            self.options.get('next_mac_change_label_x', self.ui_config['mac_timer'][0]),
+            self.options.get('next_mac_change_label_y', self.ui_config['mac_timer'][1])
+        )
+        self.ui_config['tx_power'] = (
+            self.options.get('tx_power_label_x', self.ui_config['tx_power'][0]),
+            self.options.get('tx_power_label_y', self.ui_config['tx_power'][1])
+        )
+        self.ui_config['channel'] = (
+            self.options.get('channel_label_x', self.ui_config['channel'][0]),
+            self.options.get('channel_label_y', self.ui_config['channel'][1])
+        )
+        self.ui_config['stealth'] = (
+            self.options.get('stealth_label_x', self.ui_config['stealth'][0]),
+            self.options.get('stealth_label_y', self.ui_config['stealth'][1])
+        )
+
         # Enhanced initialization sequence
         try:
             if not self._validate_interface():


### PR DESCRIPTION
This pull request refactors the Neurolyzer plugin to allow for complete customization of its UI label positions via `config.toml`.

Previously, the coordinates for the UI labels were hardcoded, requiring users to modify the plugin file directly to adjust the layout. This change makes the UI fully configurable, improving user experience and maintainability.

### Key Changes:

*   **Configurable Coordinates**: The x/y positions for all labels (`mode`, `next_mac_change`, `tx_power`, `channel`, `stealth`) can now be set in the user's `config.toml` file.
*   **Graceful Fallback**: The plugin will use the original default positions if the new configuration values are not specified, ensuring backward compatibility.
*   **Updated Documentation**: The `README.md` has been updated to document all the new configuration options and includes a revised `config.toml` example for clarity.