### PR TITLE
fix(age): seed the handshake count correctly and stop mangling the points

### DIFF
--- a/age.py
+++ b/age.py
@@ -303,6 +303,16 @@ class Age(plugins.Plugin):
         self.points_map = self.options.get('points_map', self.points_map)
         self.show_personality = self.options.get('show_personality', False)
 
+        # /root/handshakes is not where every build keeps them: jayofelony images
+        # use /etc/pwnagotchi/handshakes. Follow bettercap's configured directory.
+        handshake_dir = self.options.get('handshake_dir')
+        if not handshake_dir:
+            try:
+                handshake_dir = pwnagotchi.config['bettercap']['handshakes']
+            except (AttributeError, KeyError, TypeError):
+                handshake_dir = self.handshake_dir
+        self.handshake_dir = handshake_dir
+
         self.load_data()
         self.initialize_handshakes()
 
@@ -321,7 +331,8 @@ class Age(plugins.Plugin):
         if self.handshake_count == 0 and os.path.isdir(self.handshake_dir):
             count = 0
             for root, dirs, files in os.walk(self.handshake_dir):
-                count += sum(1 for f in files if f.endswith('.pcap'))
+                # pwnagotchi writes .pcapng, so .pcap alone never matched anything.
+                count += sum(1 for f in files if f.endswith(('.pcap', '.pcapng')))
             self.handshake_count = count
             self.total_handshakes_lifetime = max(self.total_handshakes_lifetime, count)
             logging.info(f"[Age] Initialized with {self.handshake_count} handshakes")
@@ -794,6 +805,12 @@ class Age(plugins.Plugin):
     def abrev_number(self, num):
         for unit in ['', 'K', 'M', 'B']:
             if abs(num) < 1000:
-                return f"{num:.1f}{unit}".rstrip('.0')
+                # rstrip removes every trailing character in the set, not the
+                # suffix, so this used to turn 0 into '', 100 into '1' and 120
+                # into '12'.
+                text = f"{num:.1f}"
+                if text.endswith('.0'):
+                    text = text[:-2]
+                return f"{text}{unit}"
             num /= 1000.0
         return f"{num:.1f}T"


### PR DESCRIPTION
Three independent bugs, all found running age 4.0.0 on a jayofelony 2.9.5.6 build.

### 1. `Pts` shows a label with nothing beside it

`abrev_number()` tries to drop a trailing `.0`:

```python
return f"{num:.1f}{unit}".rstrip('.0')
```

`rstrip` removes every trailing character that is a member of the set, not the suffix, so anything ending in a zero is truncated:

```
     0 -> ''
    10 -> '1'
   100 -> '1'
   120 -> '12'
  1500 -> '15'
```

On a fresh install the points are zero, so the element renders as an empty string and looks like the plugin is broken. Later on it silently shows wrong numbers.

### 2. The handshake directory is hardcoded

```python
self.handshake_dir = '/root/handshakes'
```

jayofelony builds keep them in `/etc/pwnagotchi/handshakes`, which is what `bettercap.handshakes` points at. `initialize_handshakes()` therefore finds nothing and leaves the count at zero. It now reads the configured directory, with a `handshake_dir` option to override and the old path as fallback.

### 3. The scan looks for the wrong extension

```python
count += sum(1 for f in files if f.endswith('.pcap'))
```

pwnagotchi writes `.pcapng`. Even pointed at the right directory the seed count stayed at zero. Both extensions are counted now.

Points 2 and 3 only affect the initial seeding, since `on_handshake` increments the counter live afterwards, but together they mean a device with existing captures always starts from nothing.

### Testing

Pi Zero 2 W, Waveshare 2.13 v3, jayofelony 2.9.5.6. Before the change the log reported nothing at load and `Pts` was empty. After it:

```
[Age] Initialized with 16 handshakes
```

Seeding still only runs when the stored count is zero, so an existing `/root/age_strength.json` is left alone.